### PR TITLE
Add Zero coordinate to StatusBar

### DIFF
--- a/GGEasy/mainwindow.cpp
+++ b/GGEasy/mainwindow.cpp
@@ -95,6 +95,10 @@ MainWindow::MainWindow(QWidget* parent)
         ui.statusbar->showMessage(QString("X = %1, Y = %2").arg(point.x()).arg(point.y()));
     });
 
+    connect(ui.graphicsView, &GraphicsView::mouseMove2, [this](const QPointF& point, const QPointF& gpoint) {
+        ui.statusbar->showMessage(QString("Home: X = %1, Y = %2\t\t\t\tZero: X = %3, Y = %4").arg(point.x()).arg(point.y()).arg(gpoint.x()).arg(gpoint.y()));
+    });
+
     ui.treeView->setModel(new FileTree::Model(ui.treeView));
 
     connect(ui.treeView, &FileTree::View::saveGCodeFile, this, &MainWindow::saveGCodeFile);

--- a/static_libs/graphicsview/graphicsview.cpp
+++ b/static_libs/graphicsview/graphicsview.cpp
@@ -612,7 +612,12 @@ void GraphicsView::mouseMoveEvent(QMouseEvent* event) {
     if (ruler_ && rulerCtr & 0x1)
         rulPt2 = point;
 
-    emit mouseMove(point);
+    // расчёт смещения для нулевых координат
+    QPointF hpoint = App::project()->homePos();
+    QPointF zpoint = App::project()->zeroPos();
+    QPointF gpoint = hpoint - zpoint + point;
+
+    emit mouseMove2(point, gpoint);
     scene()->update();
 }
 

--- a/static_libs/graphicsview/graphicsview.h
+++ b/static_libs/graphicsview/graphicsview.h
@@ -52,6 +52,7 @@ public:
 signals:
     void fileDroped(const QString&);
     void mouseMove(const QPointF&);
+    void mouseMove2(const QPointF&, const QPointF&);
     void mouseClickR(const QPointF&);
     void mouseClickL(const QPointF&);
 


### PR DESCRIPTION
Первое улучшение. Нулевые координаты в статус баре. Крайне полезная опция когда нужно в Candle сместиться к выбранному элементу указав координаты.
![изображение](https://github.com/XRay3D/GERBER_X3/assets/848990/253c7447-8173-442e-880e-6e9a4ec8c17a)
