### PR TITLE
CheckBox behavior

### DIFF
--- a/plugins/gcode/drill/drill_form.cpp
+++ b/plugins/gcode/drill/drill_form.cpp
@@ -160,8 +160,11 @@ void Form::initToolTable() {
     ui->toolTable->setVerticalHeader(header);
     checkBox = new QCheckBox(cornerButton);
     checkBox->setFocusPolicy(Qt::NoFocus);
-    checkBox->setGeometry(Header::getRect(cornerButton->rect()) /*.translated(1, -4)*/);
-    connect(checkBox, &QCheckBox::clicked, [this](bool checked) { header->setAll(checked); });
+    checkBox->setGeometry(Header::getRect(cornerButton->rect()) /*.translated(1, -4)*/);    
+    connect(checkBox, &QCheckBox::clicked, [this](bool checked) {
+        Qt::CheckState state = header->checkBoxState;
+        header->setAll(checked ? (state == Qt::Unchecked ? 1 : 0) : 0);
+    });
     connect(header, &Header::onChecked, [this](int idx) {
         if (model) {
             int fl {};
@@ -169,7 +172,8 @@ void Form::initToolTable() {
                 if (model->useForCalc(i))
                     ++fl;
 
-            checkBox->setCheckState(!fl ? Qt::Unchecked : (fl == model->rowCount() ? Qt::Checked : Qt::PartiallyChecked));
+            header->checkBoxState = !fl ? Qt::Unchecked : (fl == model->rowCount() ? Qt::Checked : Qt::PartiallyChecked);
+            checkBox->setCheckState(header->checkBoxState);
             pbCreate->setEnabled(fl);
         }
     });

--- a/plugins/gcode/drill/drill_header.h
+++ b/plugins/gcode/drill/drill_header.h
@@ -12,6 +12,8 @@ public:
     Header(Qt::Orientation orientation, QWidget* parent = nullptr);
     ~Header() override;
 
+    Qt::CheckState checkBoxState;
+
     enum {
         XOffset = 5,
         DelegateSize = 16


### PR DESCRIPTION
Модуль Drill. Смена поведения CheckBox в заголовке Aperture / Tool. Ранее состояние Qt::PartiallyChecked менялось на Qt::Checked. Теперь на Qt::Unchecked. Ранее нельзя было снять галочку со всех, кликнув на CheckBox заголовка, если не выбраны инструменты для всех отверстий. Теперь можно. Такое поведение более логично. Действие снять все галочки используется чаще.

---
Потратил много часов на проверку всевозможных решений. Не нашёл отключения установки значения на Qt::Checked при клике. Чтобы в checkState() сохранялось старое значение. Пришлось добавить переменную для хранения состояния. Получилось простое решение. Стоившее кучу времени.