### PR TITLE
Make Circle and Rectangle from Item

### DIFF
--- a/static_libs/common/project.cpp
+++ b/static_libs/common/project.cpp
@@ -359,6 +359,30 @@ int Project::addShape(Shapes::Shape* const shape) {
     return newId;
 }
 
+int Project::makeShapeCircle(const QPointF& center, const QPointF& rad) {
+    int type = GiType::ShCircle;
+    if (App::shapePlugins().contains(type)) {
+        Shapes::Shape *item = App::shapePlugin(type)->createShape(center);
+        item->setPt(rad);
+        addShape(item);
+        item->setSelected(true);
+        return 1;
+    }
+    return 0;
+}
+
+int Project::makeShapeRectangle(const QPointF& center, const QPointF& rect) {
+    int type = GiType::ShRectangle;
+    if (App::shapePlugins().contains(type)) {
+        Shapes::Shape *item = App::shapePlugin(type)->createShape(center);
+        item->setPt(rect);
+        addShape(item);
+        item->setSelected(true);
+        return 1;
+    }
+    return 0;
+}
+
 bool Project::contains(FileInterface* file) {
     for (const auto& [id, sp] : files_)
         if (sp.get() == file)

--- a/static_libs/common/project.h
+++ b/static_libs/common/project.h
@@ -88,6 +88,8 @@ public:
     int contains(const QString& name);
 
     // Shape
+    int makeShapeCircle(const QPointF& center, const QPointF& rad);
+    int makeShapeRectangle(const QPointF& center, const QPointF& rect);
     int addShape(Shapes::Shape* const shape);
     Shapes::Shape* shape(int id);
     void deleteShape(int id);

--- a/static_libs/gi/gi_datasolid.cpp
+++ b/static_libs/gi/gi_datasolid.cpp
@@ -69,6 +69,10 @@ void GiDataSolid::redraw() {
     // update();
 }
 
+Paths& GiDataSolid::getPaths() {
+    return paths_;
+}
+
 void GiDataSolid::setPaths(Paths paths, int alternate) {
     auto t {transform()};
     auto a {qRadiansToDegrees(asin(t.m12()))};

--- a/static_libs/gi/gi_datasolid.h
+++ b/static_libs/gi/gi_datasolid.h
@@ -28,6 +28,7 @@ public:
     int type() const override;
     // GraphicsItem interface
     void redraw() override;
+    Paths& getPaths();
     void setPaths(Paths paths, int alternate = {}) override;
     // GraphicsItem interface
     void changeColor() override;

--- a/static_libs/graphicsview/graphicsview.h
+++ b/static_libs/graphicsview/graphicsview.h
@@ -70,6 +70,7 @@ private:
     QPointF point, rulPt1, rulPt2;
 
     void drawRuller(QPainter* painter, const QRectF& rect) const;
+    void GiToShapeEvent(QMouseEvent* event, QGraphicsItem* item);
     // QWidget interface
 protected:
     void dragEnterEvent(QDragEnterEvent* event) override;


### PR DESCRIPTION
Создание круга и прямоугольника на основе объекта. Отверстий Drill и данных DataSolid. Открывает меню при нажатии правой кнопки мыши на объектах с этими типами.
Мне не хватало этой функции для создания углублений под круглые конденсаторы и микросхемы. Это нужно при высоте материала больше 1,5мм. Типа оргалита или оргстекла. Приходилось создавать круги и прямоугольники руками.

Реализация конечно хромает. Не факт, что сделана правильная последовательность вызова функций. Была задача сделать, чтобы работало. Пришлось буквально по шагам разбираться как это всё реализовать. Методом научного тыка.

Код работает, но при вызове меню перестают подсвечиваться элементы. Тут я не понимаю, как правильно реализовать эту функцию, либо, что нужно вызвать для восстановления нормальной работы.