### PR TITLE
Drill module bug create

### DIFF
--- a/plugins/gcode/drill/drill_form.cpp
+++ b/plugins/gcode/drill/drill_form.cpp
@@ -428,9 +428,9 @@ void Form::createFile() {
                             pathsMap[row.toolId].paths.push_back(path);
                     else
                         pathsMap[row.toolId].paths.push_back(item->paths().front());
-                }
-            }
+                }            
             model->setCreate(i++, !pathsMap.contains(row.toolId));
+            }
         }
 
         for (auto [usedToolId, _] : pathsMap) {

--- a/plugins/gcode/drill/drill_form.cpp
+++ b/plugins/gcode/drill/drill_form.cpp
@@ -429,7 +429,7 @@ void Form::createFile() {
                     else
                         pathsMap[row.toolId].paths.push_back(item->paths().front());
                 }            
-            model->setCreate(i++, !pathsMap.contains(row.toolId));
+                model->setCreate(i++, !pathsMap.contains(row.toolId));
             }
         }
 


### PR DESCRIPTION
Баг в модуле сверловки. model->setCreate(i++, !pathsMap.contains(row.toolId)); вызывалась для каждой строки, независимо от выбора пользователя. Как результат, создавалось УП для всех возможных отверстий.

Так же есть проблема, когда при выборе строки, отверстия не подсвечиваются зелёным. Это происходит в случае, когда у них выбран инструмент и не стоит галочка. В версии 8.1 этой проблемы не было. Это так же создаёт неудобство в использовании.